### PR TITLE
Add Subscriber::read_filtered()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,13 +47,13 @@ repos:
       - id: zizmor
   # JSON
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.36.0
+    rev: 0.36.2
     hooks:
       - id: check-github-actions
       - id: check-github-workflows
   # Markdown
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.20.0
+    rev: v0.21.0
     hooks:
       - id: markdownlint-cli2
         exclude: ^LICENSE\.md$

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -209,13 +209,12 @@ impl<T> Clone for Observer<T> {
 /// [`mark_changed()`](Self::mark_changed) to explicitly mark the current
 /// value as _changed_ or reset it to _unchanged_ by calling
 /// [`read_ack()`](Self::read_ack).
-#[allow(missing_debug_implementations)]
 pub struct Subscriber<T> {
     phantom: PhantomData<T>,
 }
 
 impl<T> Subscriber<T> {
-    /// Read the current value
+    /// Reads the current value.
     ///
     /// The current value is considered as _unseen_ until accessing it.
     /// with [`read_ack()`](Self::read_ack).
@@ -227,7 +226,7 @@ impl<T> Subscriber<T> {
         unimplemented!()
     }
 
-    /// Read and acknowledge the current value
+    /// Reads and acknowledges the current value.
     ///
     /// The current value is marked as _seen_ and therefore considered
     /// as _unchanged_ from now on.
@@ -236,6 +235,22 @@ impl<T> Subscriber<T> {
     /// again while already holding a read lock might cause a deadlock!
     #[must_use]
     pub fn read_ack(&mut self) -> Ref<T> {
+        unimplemented!()
+    }
+
+    /// Reads the first value that satisfies the filter condition.
+    ///
+    /// Applies the given filter function to the current value and all
+    /// subsequent observed values. Returns a reference to the first value
+    /// for which `filter_fn` returned `true`.
+    #[expect(unused_variables, clippy::unused_async)]
+    pub async fn read_filtered<F>(
+        &mut self,
+        filter_fn: F,
+    ) -> Result<Ref<T>, OrphanedSubscriberError>
+    where
+        F: FnMut(&T) -> bool,
+    {
         unimplemented!()
     }
 
@@ -256,7 +271,7 @@ impl<T> Subscriber<T> {
     /// # Errors
     ///
     /// Returns `Err(OrphanedSubscriberError)` if the subscriber is disconnected from the publisher.
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub async fn changed(&mut self) -> Result<(), OrphanedSubscriberError> {
         unimplemented!()
     }
@@ -268,7 +283,7 @@ impl<T> Subscriber<T> {
     /// # Errors
     ///
     /// Returns an error if the publisher has been dropped.
-    #[allow(clippy::unused_async)]
+    #[expect(clippy::unused_async)]
     pub async fn read_changed(&mut self) -> Result<Ref<T>, OrphanedSubscriberError> {
         unimplemented!()
     }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -200,6 +200,20 @@ impl<T> Subscriber<T> {
         Ref(self.rx.borrow_and_update())
     }
 
+    pub async fn read_filtered<F>(
+        &mut self,
+        filter_fn: F,
+    ) -> Result<Ref<'_, T>, OrphanedSubscriberError>
+    where
+        F: FnMut(&T) -> bool,
+    {
+        self.rx
+            .wait_for(filter_fn)
+            .await
+            .map(Ref)
+            .map_err(|_| OrphanedSubscriberError)
+    }
+
     pub fn mark_changed(&mut self) {
         self.rx.mark_changed();
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -73,6 +73,11 @@ where
     fn read_ack(&'r mut self) -> R;
 
     // TODO: How to implement this async fn properly?
+    // async fn read_filtered<F>(&mut self, filter_fn: F) -> Result<R, OrphanedSubscriberError>
+    // where
+    //     F: FnMut(&T) -> bool;
+
+    // TODO: How to implement this async fn properly?
     // async fn read_changed(&'r mut self) -> Result<R, OrphanedSubscriberError>;
 
     // TODO: How to define and implement this async fn properly?


### PR DESCRIPTION
Useful for blocking until observing an expected value or state.

Already implemented in Tokio.